### PR TITLE
fixed file path syntax generated for require("..").

### DIFF
--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -150,12 +150,26 @@
 			},
 
 			/**
+			 * @private
+			 * Fixes fileName and path to be compliant with JavaScript syntax
+			 *
+			 * @param {string} fileName
+			 * @returns {string}
+			 */
+			getFixedFileName : function (fileName) {
+				return fileName.replace(/\\/g, '\\\\');
+
+				// it may lead to errors in some browsers if we use '/' and sourcemap use '\\\\'
+				//return fileName.replace(/[\\]/g, '/');
+			},
+
+			/**
 			 * Get wrapper code preceding module original src
 			 * @param {string} filename
 			 * @returns {string}
 			 */
 			getModuleOpener: function( filename ) {
-				return "_require.def( \"" + filename + "\", function( _require, exports, module ){\n";
+				return "_require.def( \"" + this.getFixedFileName(filename) + "\", function( _require, exports, module ){\n";
 			},
 			/**
 			 * Render variable declaration code depending on what nodejs globals required in the module
@@ -230,7 +244,7 @@
 							throw new Error( "No dependency found for id = " + id );
 						}
 						return "\n	/** @type {module:" + id + "} */\n" +
-							"	" + id + " = _require( \"" + module.filename + "\" )";
+						"	" + id + " = _require( \"" + that.getFixedFileName(module.filename) + "\" )";
 					}).join( ",\n" ) + ";\n";
 
 				}
@@ -281,7 +295,7 @@
 			 * @returns {string}
 			 */
 			getScriptFooter: function( srcFilename ) {
-				return "(function(){\n_require( \"" + srcFilename + "\" );\n}());\n";
+				return "(function(){\n_require( \"" + this.getFixedFileName(srcFilename) + "\" );\n}());\n";
 			},
 
 			/**
@@ -336,7 +350,7 @@
 						thisDepEntity = null,
 						replaceModuleIdsWithResolvedFilenames = function( dep ){
 							// Replace all the module ids with fully resolved filenames
-							this.replacer.replace( dep.range[ 0 ], dep.range[ 1 ], "_require( \"" + dep.filename + "\" )" );
+							this.replacer.replace(dep.range[0], dep.range[1], "_require( \"" + that.getFixedFileName(dep.filename) + "\" )");
 						};
 
 				// dependencyMap =>


### PR DESCRIPTION
example:
incorrect: "..\..\folderName\moduleName"
correct: "..\\..\\folderName\\moduleName"

according to JavaScript standard there can't be escaping combination "\." - it leads browsers to crash.
