### PR TITLE
Fix for missing global objects

### DIFF
--- a/lib/Renderer/template/require.js
+++ b/lib/Renderer/template/require.js
@@ -51,7 +51,7 @@ var _require = (function(){
 				}
 				// Called first time, so let's run code constructing (exporting) the module
 				imports[ filename ] = factories[ filename ]( _require, module.exports, module,
-          typeof window !== "undefined" ? window : global );
+          typeof window !== "undefined" ? window : typeof global !== "undefined" ? global : null );
 				imports[ filename ].loaded = true;
 				if ( imports[ filename ].parent.children ) {
 					imports[ filename ].parent.children.push( imports[ filename ] );


### PR DESCRIPTION
@dsheiko 

I'm running your compiler in an environment without a `window` or `global` object. I think your code assumes it is being called within a UMD module if there is no `window` object, which isn't always the case.
The runtime I use throws errors with undeclared variables, so this PR adds a fallback to a null global object if both `window` and `global` are undefined.