### PR TITLE
Adjust Compiler to emit 'global.' and FileSystem to use '/'.

### DIFF
--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -286,7 +286,7 @@ module.exports = function( parser, fSys, config, srcMapGenerator, cli ) {
     * @returns {string}
     */
     getReference: function( globalProperty ) {
-       return " module.exports = window." + globalProperty + ";\n";
+       return " module.exports = global." + globalProperty + ";\n";
     },
 
     /**

--- a/lib/FileSystem.js
+++ b/lib/FileSystem.js
@@ -198,7 +198,7 @@ module.exports = function( cli ){
      * @returns {string}
      */
     getFixedFileName: function ( fileName ) {
-      return fileName.replace( /\\/g, "\\\\" );
+      return fileName.replace( /\\/g, "/" );
     },
 
      /**


### PR DESCRIPTION
First, thanks for a great tool for simpler flows that don't demand the overhead of webpack.
Here are a couple of fixes that I'd like to offer, the second being critical for my use.
- The Compiler uses 'window.' for globalProperty values but I believe it's better to use 'global.' since a 'global' reference is passed into the _require.def() that already uses window if available otherwise global.
- Problems on Windows can be avoided by using '/' not '\\' when emitting paths in FileSystem.  Currently to avoid problems I have to shelljs.sed() these references after building.
